### PR TITLE
Fix Fly example go.mod (from namespace change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ then follow the [embedded example](./examples/embedded/embedded.go).
 > Take great caution when switching adapters (such as HubAndSpoke to Clustering) as the cluster names and JS domains will change.
 > Also caution with scaling down JS regions, as there seems to be a bug with quorums failing.
 
-*Credit to [@whaaaley](https://github.com/whaaaley) for project name and icon*
+*Credit to [@whaaaley](https://github.com/whaaaley) for project name and icon, and [@delaneyj](https://github.com/delaneyj) for the inspiration.*

--- a/examples/fly/go.mod
+++ b/examples/fly/go.mod
@@ -3,7 +3,7 @@ module pillow-fly
 go 1.23.1
 
 require (
-	github.com/Nintron27/nats-pillow v0.1.0
+	github.com/Nintron27/pillow v0.4.0
 	github.com/nats-io/nats-server/v2 v2.10.22
 )
 

--- a/examples/fly/go.sum
+++ b/examples/fly/go.sum
@@ -1,5 +1,5 @@
-github.com/Nintron27/nats-pillow v0.1.0 h1:v3QQ0VTPgjwlYSd/jUr7fGYvD24No0XLnSTwyMDiIGw=
-github.com/Nintron27/nats-pillow v0.1.0/go.mod h1:OL7xhEcoqHbIe7MpHrKqwNH3KldXIyOvBGYrJH9rON4=
+github.com/Nintron27/pillow v0.4.0 h1:g+3I6kYALTajpsu8DXRJ4iT4sXJ7sXY2+NAVx12nZZA=
+github.com/Nintron27/pillow v0.4.0/go.mod h1:MtNBNU4O2J/xkaLWU9GRFs/kg+wl953uS9AJX11RIw0=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=


### PR DESCRIPTION
Quick fix to the Fly example's `go.mod` as a side effect of changing the libs namespace. *Also add Delaney to the README for project inspiration.*