### PR TITLE
Fix Shutdown() hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ then follow the [embedded example](./examples/embedded/embedded.go).
 - Reference the [examples folder](./examples) for examples of using nats-pillow.
 - This project was started and is being maintained to be used in the [Stelo Finance](https://github.com/stelofinance/stelofinance) project, so check that out for a real project example. 
 
+## Forced Opinions
+- `NoSigs` is forced to `true` for the nats-server configuration, as it generally doesn't align with embedding NATS in Go, but also causes problems with the Shutdown function due to nats-io/nats-server#6358.
+
 ## Quirks with Platform Adapters
 - FlyioClustering: Removing a region will cause any remaining machines will infinitely try to reconnect to the removed region, until they are restarted. This is probably fine, as it's just some network calls, but it is something to be aware of.
 - FlyioClustering: When JetStream is enabled all your regions must have >= 3 nodes, as JetStream clustering requires this for a quorum.

--- a/pillow.go
+++ b/pillow.go
@@ -97,6 +97,9 @@ func Run(opts ...Option) (*nats.Conn, *Server, error) {
 		}
 	}
 
+	// Disable this force when this is fixed: https://github.com/nats-io/nats-server/issues/6358
+	options.NATSSeverOptions.NoSigs = true
+
 	ns, err := server.NewServer(options.NATSSeverOptions)
 	if err != nil {
 		return nil, nil, err
@@ -134,10 +137,19 @@ func Run(opts ...Option) (*nats.Conn, *Server, error) {
 
 func (s *Server) Shutdown(ctx context.Context) error {
 	done := make(chan any)
+	if s.NATSServer == nil {
+		return nil
+	}
+
 	go func() {
-		if s.opts.NATSSeverOptions.NoSigs {
-			s.NATSServer.Shutdown()
-		}
+		// Re-enable this form of handling when this issue is fixed: https://github.com/nats-io/nats-server/issues/6358
+		//
+		// if s.opts.NATSSeverOptions.NoSigs {
+		// 	s.NATSServer.Shutdown()
+		// } else if s.NATSServer.Running() {
+		// 	s.NATSServer.Shutdown()
+		// }
+		s.NATSServer.Shutdown()
 		s.NATSServer.WaitForShutdown()
 		close(done)
 	}()


### PR DESCRIPTION
Force NoSigs to always true for the NATS server options, so that Shutdown can safely call server.Shutdown() with nil channel panic.

Closes #14 