### PR TITLE
Removed global nats client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 examples/fly/nats
+examples/embedded/nats
 go.work*

--- a/adapters.go
+++ b/adapters.go
@@ -103,10 +103,10 @@ func (c *FlyioClustering) Configure(ctx context.Context) Option {
 	}
 
 	return func(o *options) error {
-		o.NATSSeverOptions.ServerName = "fly-" + env.machineID
-		o.NATSSeverOptions.Routes = inRegionRoutes
-		o.NATSSeverOptions.Gateway = gatewayOpts
-		o.NATSSeverOptions.Cluster = server.ClusterOpts{
+		o.natsSeverOptions.ServerName = "fly-" + env.machineID
+		o.natsSeverOptions.Routes = inRegionRoutes
+		o.natsSeverOptions.Gateway = gatewayOpts
+		o.natsSeverOptions.Cluster = server.ClusterOpts{
 			ConnectRetries: 5,
 			Name:           clusterName,
 			Port:           ClusterPort,
@@ -161,24 +161,24 @@ func (c *FlyioHubAndSpoke) Configure(ctx context.Context) Option {
 
 	return func(o *options) error {
 		if isPrimaryRegion {
-			o.NATSSeverOptions.JetStreamDomain = "hub"
-			o.NATSSeverOptions.LeafNode = server.LeafNodeOpts{
+			o.natsSeverOptions.JetStreamDomain = "hub"
+			o.natsSeverOptions.LeafNode = server.LeafNodeOpts{
 				Port: LeafNodePort,
 			}
-			o.NATSSeverOptions.Routes = primaryRegionURLs
-			o.NATSSeverOptions.Cluster = server.ClusterOpts{
+			o.natsSeverOptions.Routes = primaryRegionURLs
+			o.natsSeverOptions.Cluster = server.ClusterOpts{
 				ConnectRetries: 5,
 				Name:           c.ClusterName,
 				Port:           ClusterPort,
 			}
 		} else {
-			o.NATSSeverOptions.JetStreamDomain = "leaf-" + env.region + "-" + env.machineID
-			o.NATSSeverOptions.LeafNode = server.LeafNodeOpts{
+			o.natsSeverOptions.JetStreamDomain = "leaf-" + env.region + "-" + env.machineID
+			o.natsSeverOptions.LeafNode = server.LeafNodeOpts{
 				Remotes: remotes,
 			}
 		}
 
-		o.NATSSeverOptions.ServerName = "fly-" + env.machineID
+		o.natsSeverOptions.ServerName = "fly-" + env.machineID
 		return nil
 	}
 }
@@ -197,8 +197,8 @@ func flyioReloadRoutes(ctx context.Context, opts *options, env *flyioEnv) error 
 
 	// Check if the cluster routes have changed
 	clusterChanged := false
-	oldClusterRoutes := make([]string, 0, len(opts.NATSSeverOptions.Routes))
-	for _, route := range opts.NATSSeverOptions.Routes {
+	oldClusterRoutes := make([]string, 0, len(opts.natsSeverOptions.Routes))
+	for _, route := range opts.natsSeverOptions.Routes {
 		oldClusterRoutes = append(oldClusterRoutes, route.String())
 	}
 	newClusterRoutes := make([]string, 0, len(inRegionroutes))
@@ -253,7 +253,7 @@ func flyioReloadRoutes(ctx context.Context, opts *options, env *flyioEnv) error 
 	}
 
 	// Reload routes
-	options := opts.NATSSeverOptions.Clone()
+	options := opts.natsSeverOptions.Clone()
 	options.Routes = inRegionroutes
 	// See above as to why commented out
 	// options.Gateway.Gateways = gateways
@@ -261,7 +261,7 @@ func flyioReloadRoutes(ctx context.Context, opts *options, env *flyioEnv) error 
 	if err != nil {
 		return err
 	}
-	opts.NATSSeverOptions.Routes = inRegionroutes
+	opts.natsSeverOptions.Routes = inRegionroutes
 	// See above as to why commented out
 	// opts.NATSSeverOptions.Gateway.Gateways = gateways
 

--- a/examples/fly/fly.go
+++ b/examples/fly/fly.go
@@ -19,12 +19,11 @@ func main() {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	_, ns, err := pillow.Run(
+	ns, err := pillow.Run(
 		pillow.WithNATSServerOptions(&server.Options{
 			JetStream: true,
 			StoreDir:  "./nats",
 		}),
-		pillow.WithInProcessClient(true),
 		pillow.WithLogging(true),
 		pillow.WithPlatformAdapter(ctx, env == "prod", &pillow.FlyioClustering{
 			ClusterName: "pillow-hub",

--- a/pillow.go
+++ b/pillow.go
@@ -11,41 +11,47 @@ import (
 	"github.com/nats-io/nats.go"
 )
 
+// ErrStartupTimedOut indicates that the embedded nats server exceeded its startup
+// timeout duration.
+var ErrStartupTimedOut = errors.New("embedded nats server startup timed out")
+
 type options struct {
 	server *server.Server
 
 	// Time to wait for embedded NATS to start
-	Timeout time.Duration
+	timeout time.Duration
 
-	// The returned client will communicate in process with the NATS server if enabled
-	InProcessClient bool
+	// The returned client will communicate in-process with the NATS server if enabled
+	inProcessClient bool
 
 	// Enable NATS Logger
-	EnableLogging bool
+	enableLogging bool
 
-	NATSSeverOptions *server.Options
+	natsSeverOptions *server.Options
 }
 
 type Option func(*options) error
 
 type Server struct {
+	// Reference to the underlying nats-server server.Server
 	NATSServer *server.Server
-	opts       *options
+
+	opts *options
 }
 
 // Duration to wait for embedded NATS to start. Defaults to 5 seconds if omitted
 func WithTimeout(t time.Duration) Option {
 	return func(o *options) error {
-		o.Timeout = t
+		o.timeout = t
 		return nil
 	}
 }
 
-// If enabled the returned client from Run() (and global pillow.Client) will
-// communicate in-process and not over the network layer
-func WithInProcessClient(enable bool) Option {
+// If enabled the clients returned from *Server.NATSClient() will
+// communicate with the embedded server over the network instead of in-process.
+func WithoutInProcessClient(enable bool) Option {
 	return func(o *options) error {
-		o.InProcessClient = enable
+		o.inProcessClient = !enable
 		return nil
 	}
 }
@@ -53,7 +59,7 @@ func WithInProcessClient(enable bool) Option {
 // Enable NATS internal logging
 func WithLogging(enable bool) Option {
 	return func(o *options) error {
-		o.EnableLogging = enable
+		o.enableLogging = enable
 		return nil
 	}
 }
@@ -63,76 +69,69 @@ func WithLogging(enable bool) Option {
 // in the list of options in Run().
 func WithNATSServerOptions(natsServerOpts *server.Options) Option {
 	return func(o *options) error {
-		o.NATSSeverOptions = natsServerOpts
+		o.natsSeverOptions = natsServerOpts
 		return nil
 	}
 }
 
-// Global variable of the nats client created from Run().
-//
-// If you are starting multiple embedded NATS servers, it's recommended to use
-// the client returned from Run() as this Client will just be from the last
-// invocation of Run().
-var Client *nats.Conn
-
-// Applies all passed options and starts the NATS server, returning a client
-// connection, a server struct, and error if there was a problem starting the
-// server.
+// Applies all passed options and starts the NATS server, returning a server struct
+// and error if there was a problem starting the server.
 //
 // All configuration functions start with "With". Example WithLogging(true)
-func Run(opts ...Option) (*nats.Conn, *Server, error) {
+func Run(opts ...Option) (*Server, error) {
 	// Set default options, then override with their configured options
 	options := &options{
-		Timeout:         time.Second * 5,
-		InProcessClient: true,
-		EnableLogging:   false,
-		NATSSeverOptions: &server.Options{
+		timeout:         time.Second * 5,
+		inProcessClient: true,
+		enableLogging:   false,
+		natsSeverOptions: &server.Options{
 			NoSigs: true,
 		},
 	}
 	for _, o := range opts {
 		err := o(options)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
 	// Disable this force when this is fixed: https://github.com/nats-io/nats-server/issues/6358
-	options.NATSSeverOptions.NoSigs = true
+	options.natsSeverOptions.NoSigs = true
 
-	ns, err := server.NewServer(options.NATSSeverOptions)
+	ns, err := server.NewServer(options.natsSeverOptions)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	if options.EnableLogging {
+	if options.enableLogging {
 		ns.ConfigureLogger()
 	}
 
 	ns.Start()
 
-	if !ns.ReadyForConnections(options.Timeout) {
-		return nil, nil, errors.New("NATS startup timed out")
+	if !ns.ReadyForConnections(options.timeout) {
+		return nil, ErrStartupTimedOut
 	}
 
 	options.server = ns
 
-	clientsOpts := []nats.Option{}
-	if options.InProcessClient {
-		clientsOpts = append(clientsOpts, nats.InProcessServer(ns))
-	}
-
-	nc, err := nats.Connect(ns.ClientURL(), clientsOpts...)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	Client = nc
-
-	return nc, &Server{
+	return &Server{
 		NATSServer: ns,
 		opts:       options,
 	}, nil
+}
+
+// Returns a new nats client.
+//
+// Client will communicate in-process unless the embedded server was started with
+// WithoutInProcessClient(true)
+func (s *Server) NATSClient() (*nats.Conn, error) {
+	clientsOpts := []nats.Option{}
+	if s.opts.inProcessClient {
+		clientsOpts = append(clientsOpts, nats.InProcessServer(s.NATSServer))
+	}
+
+	return nats.Connect(s.NATSServer.ClientURL(), clientsOpts...)
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {


### PR DESCRIPTION
## Changes
- Removed the global Client variable, and single client returned from Run() in favor of Server.NATSClient() func that returns a new client each call.
- Additionally change WithInProcessClient to WithoutInProcessClient to opt out of the in-process communication to the embedded server.
- Hid internal struct fields.