### PR TITLE
Add DisableClustering option to FlyioHubAndSpoke

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -40,6 +40,12 @@ type FlyioClustering struct {
 type FlyioHubAndSpoke struct {
 	// The name to be used for the primary region cluster.
 	ClusterName string
+
+	// Disable clustering in the primary region
+	//
+	// This should only be enabled when the primary region has 1 node and you want to enable JS.
+	// Changing to a clustered deployment later may result in losing any data in JS.
+	DisableClustering bool
 }
 
 func (c *FlyioClustering) Configure(ctx context.Context) Option {
@@ -130,33 +136,30 @@ func (c *FlyioHubAndSpoke) Configure(ctx context.Context) Option {
 		urlPort = LeafNodePort
 	}
 
-	primaryRegionURLs, err := flyioGetRegionURLs(ctx, &env, env.primaryRegion, urlProtocol, urlPort)
-	if err != nil {
-		// Do nothing, regions will be empty until there is a resolution to
-		// this post: https://community.fly.io/t/machine-cannot-read-its-own-internal-dns-entry-on-startup/23278
-		//
-		// return func(o *options) error { return err }
-	}
-	// Till issue above is fixed forcefully include self so that when JS is enabled it doesn't crash on
-	// startup from empty routes, unless it's not primary region, in that case return error as there
-	// isn't much we can do to recover from this.
-	if len(primaryRegionURLs) == 0 {
-		if isPrimaryRegion {
-			selfURL, err := url.Parse("nats://[" + env.privateIP + "]:" + strconv.Itoa(ClusterPort))
-			if err != nil {
-				return func(o *options) error { return errors.New("Unable to parse NATS gateway url") }
-			}
-			primaryRegionURLs = append(primaryRegionURLs, selfURL)
-		} else {
-			return func(o *options) error { return errors.New("Unable to get primary region routes") }
+	var primaryRegionURLs []*url.URL
+	if !isPrimaryRegion || !c.DisableClustering {
+		urls, err := flyioGetRegionURLs(ctx, &env, env.primaryRegion, urlProtocol, urlPort)
+		if err != nil {
+			// Do nothing, regions will be empty until there is a resolution to
+			// this post: https://community.fly.io/t/machine-cannot-read-its-own-internal-dns-entry-on-startup/23278
+			//
+			// return func(o *options) error { return err }
 		}
-	}
-
-	remotes := make([]*server.RemoteLeafOpts, 0)
-	if !isPrimaryRegion {
-		remotes = append(remotes, &server.RemoteLeafOpts{
-			URLs: primaryRegionURLs,
-		})
+		// Till issue above is fixed forcefully include self so that when JS is enabled it doesn't crash on
+		// startup from empty routes, unless it's not primary region, in that case return error as there
+		// isn't much we can do to recover from this.
+		primaryRegionURLs = urls
+		if len(primaryRegionURLs) == 0 {
+			if isPrimaryRegion {
+				selfURL, err := url.Parse("nats://[" + env.privateIP + "]:" + strconv.Itoa(ClusterPort))
+				if err != nil {
+					return func(o *options) error { return errors.New("Unable to parse NATS gateway url") }
+				}
+				primaryRegionURLs = append(primaryRegionURLs, selfURL)
+			} else {
+				return func(o *options) error { return errors.New("Unable to get primary region routes") }
+			}
+		}
 	}
 
 	return func(o *options) error {
@@ -165,13 +168,22 @@ func (c *FlyioHubAndSpoke) Configure(ctx context.Context) Option {
 			o.natsSeverOptions.LeafNode = server.LeafNodeOpts{
 				Port: LeafNodePort,
 			}
-			o.natsSeverOptions.Routes = primaryRegionURLs
-			o.natsSeverOptions.Cluster = server.ClusterOpts{
-				ConnectRetries: 5,
-				Name:           c.ClusterName,
-				Port:           ClusterPort,
+			if !c.DisableClustering {
+				o.natsSeverOptions.Routes = primaryRegionURLs
+				o.natsSeverOptions.Cluster = server.ClusterOpts{
+					ConnectRetries: 5,
+					Name:           c.ClusterName,
+					Port:           ClusterPort,
+				}
 			}
 		} else {
+			remotes := make([]*server.RemoteLeafOpts, 0)
+			if !isPrimaryRegion {
+				remotes = append(remotes, &server.RemoteLeafOpts{
+					URLs: primaryRegionURLs,
+				})
+			}
+
 			o.natsSeverOptions.JetStreamDomain = "leaf-" + env.region + "-" + env.machineID
 			o.natsSeverOptions.LeafNode = server.LeafNodeOpts{
 				Remotes: remotes,


### PR DESCRIPTION
Add DisableClustering option to FlyioHubAndSpoke adapter so that people with very minimal deployments can still utilize JS without clustering.