### PR TITLE
Flyio Adapters: set clustering/superclustering host to 6PN

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,12 @@ Currently there are only Platform Adapters for [Flyio](https://fly.io/), and the
 
 ### Quirks w/ Platform Adapters
 - You should supply `pillow.WithPlatformAdapter` last in your `pillow.Run()` call as it will override certain nats server options for platform specific reasons, such as overridding the server name so they are unique on every machine.
-- Flyio (Clustering & HubAndSpoke): Scaling down a JetStream enabled region may cause the JS quorum to fail, or the meta leader to not be established. This renders JS unuseable, and will hopefully be fixed or addressed in a future release.
 - `FlyioClustering`: Removing a region will cause any remaining machines will infinitely try to reconnect to the removed region, until they are restarted. This is probably fine, as it's just some network calls, but it is something to be aware of.
 - `FlyioClustering`: When JetStream is enabled all your regions must have >= 3 nodes, as JetStream clustering requires this for a quorum.
 
 > [!CAUTION]
 > Take great caution when switching adapters (such as HubAndSpoke to Clustering) as the cluster names and JS domains will change.
-> Also caution with scaling down JS regions, as there seems to be a bug with quorums failing.
+> Also caution with scaling down JS regions, as removing a node that contains a stream or kv bucket can cause an outage. You should evict them as a peer before removing the machine.
 
 ## Forced Opinions
 - `NoSigs` is forced to `true` for the nats-server configuration, as it generally doesn't align with embedding NATS in Go, but also causes problems with the Shutdown function due to nats-io/nats-server#6358.

--- a/adapters.go
+++ b/adapters.go
@@ -97,6 +97,7 @@ func (c *FlyioClustering) Configure(ctx context.Context) Option {
 
 	gatewayOpts = server.GatewayOpts{
 		Name:           clusterName,
+		Host:           env.privateIP,
 		Port:           GatewayPort,
 		ConnectRetries: 5,
 		Gateways:       gateways,
@@ -109,6 +110,7 @@ func (c *FlyioClustering) Configure(ctx context.Context) Option {
 		o.natsSeverOptions.Cluster = server.ClusterOpts{
 			ConnectRetries: 5,
 			Name:           clusterName,
+			Host:           env.privateIP,
 			Port:           ClusterPort,
 		}
 		return nil
@@ -163,12 +165,14 @@ func (c *FlyioHubAndSpoke) Configure(ctx context.Context) Option {
 		if isPrimaryRegion {
 			o.natsSeverOptions.JetStreamDomain = "hub"
 			o.natsSeverOptions.LeafNode = server.LeafNodeOpts{
+				Host: env.privateIP,
 				Port: LeafNodePort,
 			}
 			o.natsSeverOptions.Routes = primaryRegionURLs
 			o.natsSeverOptions.Cluster = server.ClusterOpts{
 				ConnectRetries: 5,
 				Name:           c.ClusterName,
+				Host:           env.privateIP,
 				Port:           ClusterPort,
 			}
 		} else {


### PR DESCRIPTION
Gateway gossiping is broken currently because when a new region is spun up it advertises the wrong IP to connect to. This addresses that to explicitly have the host be Fly's 6PN address.